### PR TITLE
fixed type class issues in Operation.hs

### DIFF
--- a/GPipe-Core/src/Graphics/GPipe/Shader/Operations.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Shader/Operations.hs
@@ -83,7 +83,7 @@ instance Floating (S a Float) where
 -- | This class provides the GPU functions either not found in Prelude's numerical classes, or that has wrong types.
 --   Instances are also provided for normal 'Float's and 'Double's.
 --   Minimal complete definition: 'floor'' and 'ceiling''.
-class (IfB (RealBool a) a, OrdB (RealBool a) a, Floating a) => Real' a where
+class (IfB (RealBool a), IfB a, OrdB (RealBool a), OrdB a, Floating a) => Real' a where
   type RealBool a
   rsqrt :: a -> a
   exp2 :: a -> a
@@ -112,7 +112,5 @@ class (IfB (RealBool a) a, OrdB (RealBool a) a, Floating a) => Real' a where
 
 
 
-
-while :: IfB (S c Bool) a => (a -> S c Bool) -> (a -> a) -> a -> a
+while :: (IfB (S c Bool), IfB a) => (a -> S c Bool) -> (a -> a) -> a -> a
 while = undefined
-


### PR DESCRIPTION
I get the following errors while trying to build:

```
src/Graphics/GPipe/Shader/Operations.hs:86:8:
    `IfB' is applied to too many type arguments
    In the class declaration for Real'
```

Looking at Data.Boolean.IfB, it only takes 1 type argument.

Line 86:

``` haskell
class (IfB (RealBool a) a, OrdB (RealBool a) a, Floating a) => Real' a where
```

I believe should be:

``` haskell
class (IfB (RealBool a), IfB a, OrdB (RealBool a), OrdB a, Floating a) => Real' a where
```

Or something....

Same with 

``` haskell
while :: IfB (S c Bool) => (a -> S c Bool) -> (a -> a) -> a -> a
```

should be

``` haskell
while :: (IfB (S c Bool), IfB a) => (a -> S c Bool) -> (a -> a) -> a -> a
```
