### PR TITLE
build with stack

### DIFF
--- a/GPipe-Core/.gitignore
+++ b/GPipe-Core/.gitignore
@@ -1,0 +1,3 @@
+cabal.sandbox.config
+.stack-work/
+dist/

--- a/GPipe-Core/stack.yaml
+++ b/GPipe-Core/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- OpenGLRaw-2.5.1.0
+resolver: lts-2.22


### PR DESCRIPTION
add stack.yaml for **repeatable builds**

* builds using latest LTS that still uses GHC-7.8.*
* includes one out-of-snapshot dependency on OpenGLRaw

update .gitignore