### PR TITLE
Context manager style interface; managed threads

### DIFF
--- a/GPipe-Core/CHANGELOG.md
+++ b/GPipe-Core/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.0
+
+- Re-work interface with context provider libraries to follow `bracket` pattern
+
 ### 2.1.8
 
 - Update dependencies to make it build with stack resolver nightly-2016-09-24

--- a/GPipe-Core/GPipe.cabal
+++ b/GPipe-Core/GPipe.cabal
@@ -1,5 +1,5 @@
 name:           GPipe
-version:        2.1.8
+version:        2.2.0
 cabal-version:  >= 1.8
 build-type:     Simple
 author:         Tobias Bexelius

--- a/GPipe-Core/src/Graphics/GPipe/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Context.hs
@@ -13,7 +13,7 @@
 -- You may create a context without a window (for example for rendering to textures that are saved as pngs instead of showed), and you can create a 
 -- context that shares the object space with another context. 
 --
--- Context creation is abstracted away from GPipe, and you need a package that provides a 'ContextFactory', such as @GPipe-GLFW@.
+-- Context creation is abstracted away from GPipe, and you need a package that provides a 'ContextManager', such as @GPipe-GLFW@.
 -----------------------------------------------------------------------------
 
 module Graphics.GPipe.Context (
@@ -25,10 +25,10 @@ module Graphics.GPipe.Context (
     swapContextBuffers,
     -- * External interfaces
     -- | Users of GPipe shouldn't bother with these functions, instead use a separate window manager package such as GPipe-GLFW that will provide you with
-    --   a function of type 'ContextFactory'.
+    --   a function of type 'ContextManager'.
     --
-    --   To create a window manager package, create a 'ContextFactory' function that provides a 'ContextHandle' with all functionality needed.
-    ContextFactory,
+    --   To create a window manager package, create a 'ContextManager' function that provides a 'ContextHandle' with all functionality needed.
+    ContextManager,
     ContextHandle(..),
     withContextWindow,
     -- * Hardware exceptions

--- a/GPipe-Core/src/Graphics/GPipe/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Context.hs
@@ -36,4 +36,4 @@ module Graphics.GPipe.Context (
 )
 where
 
-import Graphics.GPipe.Internal.Context 
+import Graphics.GPipe.Internal.Context

--- a/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
@@ -50,11 +50,11 @@ import Control.Monad.Trans.Error
 import Control.Exception (throwIO)
 import Control.Monad.Trans.State.Strict
 
-type ContextFactory c ds w = ContextFormat c ds -> IO (ContextHandle w)
+type ContextFactory c ds w m a = ContextFormat c ds -> (ContextHandle w -> m a) -> m a
 
 data ContextHandle w = ContextHandle {
     -- | Like a 'ContextFactory' but creates a context that shares the object space of this handle's context. Called from same thread as created the initial context.
-    newSharedContext :: forall c ds. ContextFormat c ds -> IO (ContextHandle w),
+    withSharedContext :: forall c ds m a. ContextFormat c ds -> (ContextHandle w -> m a) -> m a,
     -- | Run an OpenGL IO action in this context, returning a value to the caller.
     --   The boolean argument will be @True@ if this call references this context's window, and @False@ if it only references shared objects
     --   The thread calling this may not be the same creating the context.
@@ -67,8 +67,6 @@ data ContextHandle w = ContextHandle {
     contextSwap :: IO (),
     -- | Get the current size of the context's default framebuffer (which may change if the window is resized). Called from same thread as created context.
     contextFrameBufferSize :: IO (Int, Int),
-    -- | Delete this context and close any associated window. Called from same thread as created context.
-    contextDelete :: IO (),
     -- | A value representing the context's window. It is recommended that this is an opaque type that doesn't have any exported functions. Instead, provide 'ContextT' actions
     --   that are implemented in terms of 'withContextWindow' to expose any functionality to the user that need a reference the context's window.
     contextWindow :: w
@@ -99,11 +97,9 @@ instance MonadTrans (ContextT w os f) where
 -- | Run a 'ContextT' monad transformer, creating a window (unless the 'ContextFormat' is 'ContextFormatNone') that is later destroyed when the action returns. This function will
 --   also create a new object space.
 --   You need a 'ContextFactory', which is provided by an auxillary package, such as @GPipe-GLFW@.
-runContextT :: (MonadIO m, MonadAsyncException m) => ContextFactory c ds w -> ContextFormat c ds -> (forall os. ContextT w os (ContextFormat c ds) m a) -> m a
+runContextT :: (MonadIO m, MonadAsyncException m) => ContextFactory c ds w m a -> ContextFormat c ds -> (forall os. ContextT w os (ContextFormat c ds) m a) -> m a
 runContextT cf f (ContextT m) =
-    bracket
-        (liftIO $ cf f)
-        (liftIO . contextDelete)
+    cf f
         $ \ h -> do cds <- liftIO newContextDatas
                     cd <- liftIO $ addContextData cds
                     let ContextT i = initGlState
@@ -113,16 +109,17 @@ runContextT cf f (ContextT m) =
 -- | Run a 'ContextT' monad transformer inside another one, creating a window (unless the 'ContextFormat' is 'ContextFormatNone') that is later destroyed when the action returns. The inner 'ContextT' monad
 -- transformer will share object space with the outer one. The 'ContextFactory' of the outer context will be used in the creation of the inner context.
 runSharedContextT :: (MonadIO m, MonadAsyncException m) => ContextFormat c ds -> ContextT w os (ContextFormat c ds) (ContextT w os f m) a -> ContextT w os f m a
-runSharedContextT f (ContextT m) =
-    bracket
-        (do (h',(_,cds)) <- ContextT ask
-            h <- liftIO $ newSharedContext h' f
+runSharedContextT f (ContextT m) = do
+    h' <- ContextT $ asks fst
+    withSharedContext h' f $ \h -> do
+      bracket
+        (do cds <- ContextT $ asks (snd . snd)
             cd <- liftIO $ addContextData cds
             return (h,cd)
         )
         (\(h,cd) -> do cds <- ContextT $ asks (snd . snd)
                        liftIO $ do removeContextData cds cd
-                                   contextDelete h)
+                       )
         $ \(h,cd) -> do cds <- ContextT $ asks (snd . snd)
                         let ContextT i = initGlState
                             rs = (h, (cd, cds))

--- a/GPipe-Core/stack.yaml
+++ b/GPipe-Core/stack.yaml
@@ -1,6 +1,5 @@
 flags: {}
 packages:
 - '.'
-resolver: nightly-2016-09-24
-extra-deps:
-- exception-transformers-0.4.0.4 
+resolver: lts-7.8
+extra-deps: []


### PR DESCRIPTION
This is designed to work with [GPipe-GLFW/context-manager](https://github.com/plredmond/GPipe-GLFW/tree/context-manager).

Summary:

* Rewrite `ContextFactory`, `runContextT`, `runSharedContextT` to allow context libraries to use the [`bracket`](https://hackage.haskell.org/package/exception-transformers/docs/Control-Monad-Exception.html#v:bracket)-pattern to ensure their own resources are cleaned up.
* Rewrite GPipe-GLFW to implement the bracket-pattern interface.
* Rarchitect GPipe-GLFW to orient around the idea of one-context-per-thread, using the main thread as a context factory, and reducing [`makeContextCurrent`](http://www.glfw.org/docs/latest/group__context.html#ga1c04dc242268f827290fe40aa1c91157) calls to once per context/thread. This is simpler than the previous implementation which treated the main-thread as a mutex'd render thread, and it potentially reduces pipeline flushes, according to the GLFW docs:
  > By default, making a context non-current implicitly forces a pipeline flush.

Outstanding issues, mostly around `runSharedContextT`:

* [GPipe-GLFW/context-manager](https://github.com/plredmond/GPipe-GLFW/tree/context-manager) as written fixes `m` to `IO`, therefore shared-contexts won't typecheck (`newSharedContext`/`withSharedContext` uses `forall ... m`). Fixing to `IO` is a workaround for the fact that both `forkIO` and `asyncBound` take an `IO ()` action, not a generic `MonadIO m => m ()`. Since we need to run the application programmers' monad transformer stack in a bound thread (not the mainthread) we fix to `IO` to make it possible. Possible solutions:
  * Change GPipe to take an `IO` action instead of a generic monad stack. Application programmers can build their monad transformer stack in the `IO` action in GPipe.
  * Use a library like [`forkable-monad`](https://hackage.haskell.org/package/forkable-monad/docs/Control-Concurrent-Forkable.html) or `monad-fork` in GPipe-GLFW and require that users' monad stacks implement the generic `forkIO` implementation.
* The return value of `runSharedContextT` implies the shared context thread is run synchronously with the original context, not in parallel. If we remove the return value, making shared contexts parallel will be trivial with the changes to GPipe-GLFW.
* The arguments to `runSharedContextT` don't allow for application programmers to pass configuration to the context managing library (eg. for window title, size, or fullscreen settings). If that's not a use case GPipe wants to support, let's declare all shared contexts windowless and change the signatures or docs to reflect that.