### PR TITLE
New window handler interface tweaks

### DIFF
--- a/GPipe-Core/src/Graphics/GPipe/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Context.hs
@@ -20,6 +20,7 @@ module Graphics.GPipe.Context (
     -- * Contexts
     ContextT(),
     runContextT,
+    withThread,
     
     -- * Windows
     Window(),

--- a/GPipe-Core/src/Graphics/GPipe/Format.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Format.hs
@@ -27,6 +27,7 @@ module Graphics.GPipe.Format (
     StencilRenderable(),
     -- * Context formats
     WindowFormat(..),
+    ContextColorFormat(), -- XXX: Maybe this needs to be renamed?
     windowBits,
     WindowBits
 )

--- a/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
@@ -288,11 +288,12 @@ getWindowSize (Window wid) = ContextT $ do
       (x,y) <- liftIO $ contextFrameBufferSize ctx w
       return $ V2 x y
 
--- | Use the context window handle, which type is specific to the window system used. This handle shouldn't be returned from this function
-withContextWindow :: MonadIO m => Window os c ds -> (Maybe (ContextWindow ctx) -> IO a) -> ContextT ctx os m a
+-- | Use the context window handle, which type is specific to the window system used. This handle shouldn't be returned from this function.
+-- If there is no window with the given id, the given function is not called and 'Nothing' is returned.
+withContextWindow :: MonadIO m => Window os c ds -> (ContextWindow ctx -> IO a) -> ContextT ctx os m (Maybe a)
 withContextWindow (Window wid) m = ContextT $ do
   wmap <- lift $ gets perWindowState
-  liftIO $ m (snd <$> IMap.lookup wid wmap)
+  liftIO $ mapM m (snd <$> IMap.lookup wid wmap)
 
 {-}
 -- | This is only used to finalize nonShared objects such as VBOs and FBOs

--- a/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
@@ -164,8 +164,8 @@ instance MonadTrans (ContextT ctx os) where
 
 -- | Run a 'ContextT' monad transformer that encapsulates an object space.
 --   You need an implementation of a 'ContextHandler', which is provided by an auxillary package, such as @GPipe-GLFW@.
-runContextT :: (MonadIO m, MonadAsyncException m, ContextHandler ctx) => ContextHandlerParameters ctx -> (forall os. ContextT ctx os m a) -> m a
-runContextT chp (ContextT m) = do
+runContextT :: (MonadIO m, MonadAsyncException m, ContextHandler ctx) => Proxy ctx -> ContextHandlerParameters ctx -> (forall os. ContextT ctx os m a) -> m a
+runContextT Proxy chp (ContextT m) = do
     cds <- liftIO newContextDatas
     bracket
      (liftIO $ contextHandlerCreate chp)
@@ -227,7 +227,7 @@ getLastContextWin :: (ContextHandler ctx, MonadIO m) => ContextT ctx os m (Conte
 getLastContextWin = ContextT $ do
   cs <- lift get
   let wid = lastUsedWin cs
-  if wid >= 0
+  if wid > 0
     then return (snd $ perWindowState cs ! wid)
     else do --Create hidden window
       ContextEnv ctx cds <- ask

--- a/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
@@ -58,7 +58,7 @@ import Control.Monad.Trans.State.Strict
 
 class ContextHandler ctx where
   -- | Implementation specific context handler parameters, eg error handling and event processing policies
-  type ContextHandlerParameters ctx
+  data ContextHandlerParameters ctx
   -- | Implementation specific window type
   type ContextWindow ctx
   -- | Implementation specific window parameters, eg initial size and border decoration
@@ -164,8 +164,8 @@ instance MonadTrans (ContextT ctx os) where
 
 -- | Run a 'ContextT' monad transformer that encapsulates an object space.
 --   You need an implementation of a 'ContextHandler', which is provided by an auxillary package, such as @GPipe-GLFW@.
-runContextT :: (MonadIO m, MonadAsyncException m, ContextHandler ctx) => Proxy ctx -> ContextHandlerParameters ctx -> (forall os. ContextT ctx os m a) -> m a
-runContextT Proxy chp (ContextT m) = do
+runContextT :: (MonadIO m, MonadAsyncException m, ContextHandler ctx) => ContextHandlerParameters ctx -> (forall os. ContextT ctx os m a) -> m a
+runContextT chp (ContextT m) = do
     cds <- liftIO newContextDatas
     bracket
      (liftIO $ contextHandlerCreate chp)

--- a/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Context.hs
@@ -288,12 +288,11 @@ getWindowSize (Window wid) = ContextT $ do
       (x,y) <- liftIO $ contextFrameBufferSize ctx w
       return $ V2 x y
 
--- | Use the context window handle, which type is specific to the window system used. This handle shouldn't be returned from this function.
--- If there is no window with the given id, the given function is not called and 'Nothing' is returned.
-withContextWindow :: MonadIO m => Window os c ds -> (ContextWindow ctx -> IO a) -> ContextT ctx os m (Maybe a)
+-- | Use the context window handle, which type is specific to the window system used. This handle shouldn't be returned from this function
+withContextWindow :: MonadIO m => Window os c ds -> (Maybe (ContextWindow ctx) -> IO a) -> ContextT ctx os m a
 withContextWindow (Window wid) m = ContextT $ do
   wmap <- lift $ gets perWindowState
-  liftIO $ mapM m (snd <$> IMap.lookup wid wmap)
+  liftIO $ m (snd <$> IMap.lookup wid wmap)
 
 {-}
 -- | This is only used to finalize nonShared objects such as VBOs and FBOs


### PR DESCRIPTION
### Summary

* Expose `ContextColorFormat` because application programmer code needs it
* Add associated data `ContextHandlerParameters` modeled after `WindowParameters`
* Add a *hack* `withThread` for multithreaded applications
   * It starts the new thread with a fresh `ContextState`, which is probably wrong
   * It starts the new thread with the existing `ContextEnv`, which contains an MVar so is probably fine

---

`withThread` enables multithreaded applications, so I tried to write one which writes buffers on a sub thread, while continuously rendering on the main thread.
* [cd Smoketests && stack test Smoketests:split](https://github.com/plredmond/GPipe-GLFW/blob/new-window-handling-interface/Smoketests/src/Split.hs)
   * It's buggy on my machine. Sometimes the sub-thread fails to create a window, sometimes it succeeds but the rendering has some kind of buffer fighting.
      * ~~Failures emit this error `Error'PlatformError: NSGL: Failed to create OpenGL pixel format`~~ This was due to OSX "automatic graphics switching".
     * There is a MVar race which can lead to the "thread blocked indefinitely in an MVar operation" error. I'm not sure whether this is from an MVar in GPipe or GPipe-GLFW. All of the MVars used in GPipe-GLFW are accessed via withMVar though.
   * It doesn't currently make parent contexts uncurrent before creating child contexts, so it probably will just crash on windows; but this is an easy fix.