### PR TITLE
Increase upper version bound on base

### DIFF
--- a/GPipe-Core/GPipe.cabal
+++ b/GPipe-Core/GPipe.cabal
@@ -21,7 +21,7 @@ data-files:     CHANGELOG.md
 
 library
   hs-source-dirs:   src
-  build-depends:    base >= 4.9 && < 4.10,
+  build-depends:    base >= 4.9 && < 5,
                     transformers >= 0.5.2 && < 0.6,
                     exception-transformers >= 0.3 && < 0.5,
                     containers >= 0.5 && < 0.6,


### PR DESCRIPTION
In my own tests, I can confirm that GPipe works with base 4.10 and GHC 8.2, but the cabal file needs to be updated to allow this.

I don't know if you want the upper bound to be `4.11` or `5`? I went with the latter. I'm sure you could easily change it yourself, but if you don't have the time let me know and I will adjust it however you'd like.