### PR TITLE
Draft update to ghc-8.4.3 via stack lts-12.1, requires new Semigroup …

### DIFF
--- a/GPipe-Core/GPipe.cabal
+++ b/GPipe-Core/GPipe.cabal
@@ -21,7 +21,7 @@ data-files:     CHANGELOG.md
 
 library
   hs-source-dirs:   src
-  build-depends:    base >= 4.9 && < 4.11,
+  build-depends:    base >= 4.9 && < 5,
                     transformers >= 0.5.2 && < 0.6,
                     exception-transformers >= 0.3 && < 0.5,
                     containers >= 0.5 && < 0.6,

--- a/GPipe-Core/src/Graphics/GPipe/Internal/FragmentStream.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/FragmentStream.hs
@@ -33,7 +33,7 @@ data FragmentStreamData = FragmentStreamData RasterizationName ExprPos Primitive
 
 -- | A @'FragmentStream' a @ is a stream of fragments of type @a@. You may append 'FragmentStream's using the 'Monoid' instance, and you
 --   can operate a stream's values using the 'Functor' instance (this will result in a shader running on the GPU).
-newtype FragmentStream a = FragmentStream [(a, FragmentStreamData)] deriving Monoid
+newtype FragmentStream a = FragmentStream [(a, FragmentStreamData)] deriving (Semigroup, Monoid)
 
 instance Functor FragmentStream where
         fmap f (FragmentStream xs) = FragmentStream $ map (first f) xs

--- a/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveArray.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveArray.hs
@@ -139,9 +139,11 @@ data PrimitiveArrayInt p a = PrimitiveArraySimple (PrimitiveTopology p) Int Base
 -- | An array of primitives
 newtype PrimitiveArray p a = PrimitiveArray {getPrimitiveArray :: [PrimitiveArrayInt p a]}
 
+instance Semigroup (PrimitiveArray p a) where
+    PrimitiveArray a <> PrimitiveArray b = PrimitiveArray (a ++ b)
+
 instance Monoid (PrimitiveArray p a) where
     mempty = PrimitiveArray []
-    mappend (PrimitiveArray a) (PrimitiveArray b) = PrimitiveArray (a ++ b)
 
 instance Functor (PrimitiveArray p) where
     fmap f (PrimitiveArray xs) = PrimitiveArray  $ fmap g xs

--- a/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveStream.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveStream.hs
@@ -46,7 +46,7 @@ data PrimitiveStreamData = PrimitiveStreamData DrawCallName USize
 --   can operate a stream's vertex values using the 'Functor' instance (this will result in a shader running on the GPU).
 --   You may also append 'PrimitiveStream's using the 'Monoid' instance, but if possible append the origin 'PrimitiveArray's instead, as this will create more optimized
 --   draw calls.
-newtype PrimitiveStream t a = PrimitiveStream [(a, (Maybe PointSize, PrimitiveStreamData))] deriving Monoid
+newtype PrimitiveStream t a = PrimitiveStream [(a, (Maybe PointSize, PrimitiveStreamData))] deriving (Semigroup, Monoid)
 
 instance Functor (PrimitiveStream t) where
         fmap f (PrimitiveStream xs) = PrimitiveStream $ map (first f) xs

--- a/GPipe-Core/stack.yaml
+++ b/GPipe-Core/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: nightly-2017-09-20
+resolver: lts-12.1


### PR DESCRIPTION
…instances.

Please let me know if there is a preferred procedure for these GPipe dependency updates. (Backwards compatibility? Other components?).
