### PR TITLE
GHC 8.6 migration.

### DIFF
--- a/GPipe-Core/src/Graphics/GPipe/Internal/Expr.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Expr.hs
@@ -267,7 +267,10 @@ shaderbaseDeclareDef styp = do var <- T.lift $ T.lift $ T.lift $ T.lift getNext
                                return $ S $ return root
 
 shaderbaseAssignDef  (S shaderM) = do ul <- T.lift shaderM
-                                      x:xs <- get
+                                      e <- get
+                                      let (x:xs) = case e of
+                                                     (y:ys) -> e
+                                                     _      -> error "Pattern match failed"
                                       put xs
                                       T.lift $ tellAssignment' x ul
                                       return ()


### PR DESCRIPTION
adds exhaustive pattern matching to avoid the need for a monad fail instance, which is required by ghc 8.6
see https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.6

This should be backwards compatible, since the behaviour is only different in the case that we have a failed pattern match (old version would throw pattern match exception, new version calls error).