### PR TITLE
Fixed building with ghc 8.0 and ghc 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+dist-*
+.ghc.environment.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: xenial
+language: haskell
+cabal: "2.4"
+cache:
+  directories:
+    - $HOME/.cabal
+addons:
+  apt:
+    packages:
+      - libglfw3-dev
+ghc:
+  - "8.0"
+  - "8.2"
+  - "8.4"
+  - "8.6"
+install:
+  - cabal v2-build all --only-dependencies
+script:
+  - cabal v2-build all

--- a/GPipe-Core/src/Graphics/GPipe/Internal/FragmentStream.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/FragmentStream.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies, ScopedTypeVariables, TypeSynonymInstances, FlexibleInstances, GeneralizedNewtypeDeriving, Arrows, FlexibleContexts  #-}
 module Graphics.GPipe.Internal.FragmentStream where
 
@@ -10,6 +11,9 @@ import Graphics.GPipe.Internal.PrimitiveStream
 import Graphics.GPipe.Internal.PrimitiveArray
 import Control.Monad.Trans.State.Lazy
 import Data.Monoid (Monoid)
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.Boolean
 import Data.IntMap.Lazy (insert)
 import Linear.V4

--- a/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveArray.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveArray.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, ScopedTypeVariables, EmptyDataDecls, TypeFamilies, GADTs #-}
 module Graphics.GPipe.Internal.PrimitiveArray where
 
 import Graphics.GPipe.Internal.Buffer
 import Graphics.GPipe.Internal.Shader
-import Data.Monoid
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup
+#endif
+import Data.Monoid hiding ((<>))
 import Data.IORef
 
 import Data.Word
@@ -144,6 +148,9 @@ instance Semigroup (PrimitiveArray p a) where
 
 instance Monoid (PrimitiveArray p a) where
     mempty = PrimitiveArray []
+#if __GLASGOW_HASKELL__ < 804
+    mappend = (<>)
+#endif
 
 instance Functor (PrimitiveArray p) where
     fmap f (PrimitiveArray xs) = PrimitiveArray  $ fmap g xs

--- a/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveStream.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/PrimitiveStream.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies, TypeSynonymInstances, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, Arrows, GeneralizedNewtypeDeriving, PatternSynonyms #-}
 
 module Graphics.GPipe.Internal.PrimitiveStream where
@@ -17,6 +18,9 @@ import Control.Category
 import Control.Arrow
 import Control.Monad (void)
 import Data.Monoid (Monoid(..))
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.IntMap.Lazy (insert)
 import Data.Word
 import Data.Int
@@ -461,5 +465,3 @@ instance VertexInput a => VertexInput (Plucker a) where
                 e' <- toVertex -< e
                 f' <- toVertex -< f
                 returnA -< Plucker a' b' c' d' e' f'
-
-

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: ./GPipe-Core


### PR DESCRIPTION
The lower bound for base in cabal file is 4.9, which corresponds to ghc 8.0. Yet the build fails for ghc < 8.4. So I fixed it. Alternative fix would be to bump the the requirement for base to 4.11, which would probably result in a major version bump for GPipe. I've also added a few files for compatibility with cabal v2 builds and Travis CI.
https://travis-ci.org/LinuxUser404/GPipe-Core/builds/570260992