### PR TITLE
Support GHC 9.10 and modern dependencies

### DIFF
--- a/GPipe-Core/GPipe.cabal
+++ b/GPipe-Core/GPipe.cabal
@@ -22,12 +22,12 @@ data-files:     CHANGELOG.md
 library
   hs-source-dirs:   src
   build-depends:    base >= 4.9 && < 5,
-                    transformers >= 0.5.2 && < 0.6,
+                    transformers >= 0.5.2 && < 0.7,
                     exception-transformers >= 0.3 && < 0.5,
-                    containers >= 0.5 && < 0.7,
+                    containers >= 0.5 && < 0.8,
                     Boolean >= 0.2 && <0.3,
-                    hashtables >= 1.2 && < 1.4,
-                    gl >= 0.8 && <= 0.9,
+                    hashtables >= 1.2 && < 1.5,
+                    gl >= 0.8 && <= 0.10,
                     linear >= 1.18 && < 1.25
   exposed-modules:
                     Graphics.GPipe,

--- a/GPipe-Core/src/Graphics/GPipe/Internal/Shader.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Internal/Shader.hs
@@ -30,11 +30,10 @@ import Control.Monad.IO.Class
 import qualified Data.IntSet as Set
 import Control.Monad.Trans.Writer.Lazy (tell, WriterT(..), execWriterT)
 import Control.Monad.Exception (MonadException)
-import Control.Applicative (Applicative, Alternative, (<|>))
-import Control.Monad.Trans.Class (lift)
+import Control.Applicative (Alternative(..))
+import Control.Monad.Trans.Class (MonadTrans(..), lift)
 import Data.Maybe (fromJust, isJust, isNothing)
-import Control.Monad (MonadPlus, when)
-import Control.Monad.Trans.List (ListT(..))
+import Control.Monad (MonadPlus(..), when)
 import Data.Monoid (All(..), mempty)
 import Data.Either
 import Control.Monad.Trans.Reader
@@ -116,3 +115,37 @@ compileShader (Shader (ShaderM m)) = do
         return $ \ s -> case find (\(_,disc) -> getAll (disc s)) xs of
                           Nothing -> error "render: Shader evaluated to mzero"
                           Just (rf,_) -> rf s
+
+-- | Inlined ListT since it was removed from transformers 0.6
+newtype ListT m a = ListT { runListT :: m [a] }
+
+instance Functor m => Functor (ListT m) where
+    fmap f (ListT mas) = ListT (fmap (map f) mas)
+
+instance (Applicative m, Monad m) => Applicative (ListT m) where
+    pure a = ListT (pure [a])
+    ListT mfs <*> ListT mas = ListT $ do
+        fs <- mfs
+        as <- mas
+        return [f a | f <- fs, a <- as]
+
+instance Monad m => Monad (ListT m) where
+    return a = ListT (return [a])
+    ListT mas >>= f = ListT $ do
+        as <- mas
+        bss <- mapM (runListT . f) as
+        return (concat bss)
+
+instance Monad m => Alternative (ListT m) where
+    empty = ListT (return [])
+    ListT mas <|> ListT mbs = ListT $ do
+        as <- mas
+        bs <- mbs
+        return (as ++ bs)
+
+instance Monad m => MonadPlus (ListT m) where
+    mzero = empty
+    mplus = (<|>)
+
+instance MonadTrans ListT where
+    lift m = ListT (fmap (:[]) m)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772736753,
+        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "GPipe - Typesafe functional GPU graphics programming (fork)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        hp = pkgs.haskellPackages;
+        ghcWithPackages = hp.ghcWithPackages (p: [
+          p.transformers
+          p.exception-transformers
+          p.containers
+          p.Boolean
+          p.hashtables
+          p.gl
+          p.linear
+        ]);
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            ghcWithPackages
+            hp.cabal-install
+            pkgs.pkg-config
+            pkgs.libGL
+            pkgs.libGLU
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Widen dependency bounds: `transformers <0.7`, `containers <0.8`, `hashtables <1.5`, `gl <0.10`
- Inline `ListT` in `Internal.Shader` (removed from `transformers` 0.6)
- Add Nix flake for development environment

## Motivation
GPipe currently fails to build with GHC 9.10 because `transformers-0.6` removed `Control.Monad.Trans.List`. The `ListT` type is simple enough to inline directly, avoiding additional dependencies.

## Test plan
- Builds successfully with GHC 9.10.3 + linear 1.23.3 + transformers 0.6.1.1
- No changes to public API